### PR TITLE
Reduce size further, and try assembly version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /tinyrust.ll
 /tinyrust.o
 /libtinyrust.rlib
+/tinyasm
+/tinyasm.o

--- a/build-asm.sh
+++ b/build-asm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+gcc -s -c tinyasm.s
+
+objdump -dr tinyasm.o
+echo
+
+ld --gc-sections -e main -T script.ld -o payload tinyasm.o
+objcopy -j combined -O binary payload payload.bin
+
+ENTRY=$(nm -f posix payload | grep '^main ' | awk '{print $3}')
+nasm -f bin -o tinyasm -D entry=0x$ENTRY elf.s
+
+chmod +x tinyasm
+hd tinyasm
+wc -c tinyasm

--- a/tinyasm.s
+++ b/tinyasm.s
@@ -1,0 +1,20 @@
+.globl main
+.text
+main:
+	# setuid(1), to make sure we aren't root. The numeric UID is irrelevant
+	# as long as it is not zero. If we are already non-root, setuid() will
+	# fail, but that's fine because we didn't need it anyway in that case.
+	mov $0x1,%edi
+	mov $0x69,%eax
+	syscall
+
+	# x = unshare(CLONE_NEWUSER)
+	mov $0x10000000,%edi
+	mov $0x110,%eax
+	syscall
+
+	# _exit(x)
+	mov %eax,%edi
+	mov $0x3c,%eax
+	syscall
+

--- a/tinyrust.rs
+++ b/tinyrust.rs
@@ -65,16 +65,10 @@ pub fn main() {
     // First, check if we are root. If we are, we setuid to 65534
     // (which is just a dummy non-root user ID, which also happens to
     // usually be "nobody"), since we want to find out if
-    // unshare(CLONE_NEWUSER) works when we are not root.
-
-    let current_uid = getuid();
-    if (current_uid == 0) {
-        let setuid_result = setuid(65534);
-        if (setuid_result != 0) {
-            // Hmm, we failed to setuid properly. Abort now.
-            exit(2);
-        }
-    }
+    // unshare(CLONE_NEWUSER) works when we are not root. If we are already
+    // non-root, setuid() will fail, but that's fine because we didn't need it
+    // anyway in that case, so we just ignore it.
+    setuid(65534);
 
     // Now that we're not root, we can try to unshare(CLONE_NEWUSER).
     // CLONE_NEWUSER is 0x10000000.


### PR DESCRIPTION
No need to pull this if you don't want to. Just showing my results.

My assembly version came it at 153 bytes vs. Rust's 187.

However, by simplifying the Rust code to skip getuid() and ignore setuid() failure -- which is what my assembly does -- the Rust binary was reduced to 157 bytes, a mere 4 bytes larger than the assembly version.

The extra 4 bytes for Rust appears to be caused by it redundantly swizzling registers before the `exit` call:

```
mov    %rax,%rcx
mov    $0x3c,%eax
mov    %rcx,%rdi
syscall
```

Clearly, the first and third `mov` could be collapsed into a single `mov` here; the syscall doesn't care what's in `rcx`. The extra `mov` is 3 bytes, and my assembly saves another byte by using 32-bit moves rather than 64-bit.

Still fairly impressive for Rust.
